### PR TITLE
refactor: switch PDF detector logging to debug

### DIFF
--- a/lib/PdfTokenizerReader.ts
+++ b/lib/PdfTokenizerReader.ts
@@ -1,9 +1,11 @@
 // PdfTokenizerReader.ts
-import type { ITokenizer, IReadChunkOptions } from "strtok3";
+import createDebug from 'debug';
+import type {ITokenizer, IReadChunkOptions} from "strtok3";
+
+const readerDebug = createDebug('file-type:pdf:reader');
 
 export type PdfTokenizerReaderOptions = {
 	chunkSize?: number;
-	debug?: boolean;
 };
 
 export class PdfTokenizerReader {
@@ -13,16 +15,16 @@ export class PdfTokenizerReader {
 
 	private chunkSize: number;
 	private eof = false;
-	private debug: boolean;
+	private logger: ReturnType<typeof createDebug>;
 
 	constructor(tokenizer: ITokenizer, opts: PdfTokenizerReaderOptions = {}) {
 		this.tokenizer = tokenizer;
 		this.chunkSize = opts.chunkSize ?? 64 * 1024;
-		this.debug = !!opts.debug;
+		this.logger = readerDebug.extend('stream');
 	}
 
 	private log(msg: string): void {
-		if (this.debug) console.log(msg);
+		this.logger(msg);
 	}
 
 	/**
@@ -34,7 +36,7 @@ export class PdfTokenizerReader {
 	}
 
 	private async peekMayBeLess(target: Buffer): Promise<number> {
-		const opts: IReadChunkOptions = { mayBeLess: true };
+		const opts: IReadChunkOptions = {mayBeLess: true};
 		try {
 			return await this.tokenizer.peekBuffer(target, opts);
 		} catch (e: unknown) {
@@ -44,7 +46,7 @@ export class PdfTokenizerReader {
 	}
 
 	private async readMayBeLess(target: Buffer): Promise<number> {
-		const opts: IReadChunkOptions = { mayBeLess: true };
+		const opts: IReadChunkOptions = {mayBeLess: true};
 		try {
 			return await this.tokenizer.readBuffer(target, opts);
 		} catch (e: unknown) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,14 +1,16 @@
+import createDebug from 'debug';
 import sax from 'sax';
-import type { ITokenizer } from 'strtok3';
-import type { Detector, FileTypeResult } from 'file-type';
-import { PdfTokenizerReader } from './PdfTokenizerReader.js';
-import { textDecode } from '@borewit/text-codec';
+import type {ITokenizer} from 'strtok3';
+import type {Detector, FileTypeResult} from 'file-type';
+import {PdfTokenizerReader} from './PdfTokenizerReader.js';
+import {textDecode} from '@borewit/text-codec';
+
+const log = createDebug('file-type:pdf');
 
 type DictValue = true | string;
 type Dict = Record<string, DictValue>;
 
 type ProbeContext = {
-	debug: boolean;
 	log: (...args: unknown[]) => void;
 };
 
@@ -21,8 +23,8 @@ type SubtypeProbe = {
 
 const OBJ_REGEX = /^\s*(\d+)\s+(\d+)\s+obj\b/;
 
-const PDF_TYPE: Readonly<FileTypeResult> = Object.freeze({ ext: "pdf", mime: "application/pdf" });
-const AI_TYPE: Readonly<FileTypeResult> = Object.freeze({ ext: "ai", mime: "application/illustrator" });
+const PDF_TYPE: Readonly<FileTypeResult> = Object.freeze({ext: "pdf", mime: "application/pdf"});
+const AI_TYPE: Readonly<FileTypeResult> = Object.freeze({ext: "ai", mime: "application/illustrator"});
 
 /**
  * Peeks the tokenizer, and returns true if magic signature is found.
@@ -116,13 +118,13 @@ async function readDictionaryBlock(
 
 	const start = raw.indexOf("<<");
 	const end = raw.indexOf(">>", start + 2);
-	if (start === -1 || end === -1) return { dictText: null, streamInline: false };
+	if (start === -1 || end === -1) return {dictText: null, streamInline: false};
 
 	const dictText = raw.slice(start + 2, end).trim();
 	const after = raw.slice(end + 2).trim();
 	const streamInline = after === "stream" || after.startsWith("stream ");
 
-	return { dictText, streamInline };
+	return {dictText, streamInline};
 }
 
 class XmlHandler {
@@ -132,7 +134,7 @@ class XmlHandler {
 
 	constructor(opts: { onCreatorTool?: (value: string) => void } = {}) {
 		this.onCreatorTool = opts.onCreatorTool;
-		this.saxParser = sax.parser(true, { xmlns: true });
+		this.saxParser = sax.parser(true, {xmlns: true});
 
 		this.saxParser.onerror = (e: Error) => {
 			if (e.message.startsWith("Invalid character entity")) {
@@ -216,25 +218,17 @@ const subtypeProbes: SubtypeProbe[] = [createIllustratorProbe()];
  */
 async function _detectPdf(
 	tokenizer: ITokenizer,
-	opts: { debug?: boolean; maxScanLines?: number } = {}
+	opts: { maxScanLines?: number } = {}
 ): Promise<FileTypeResult | undefined> {
-	const debug = !!opts.debug;
 	const maxScanLines = opts.maxScanLines ?? 50_000;
+	const ctx: ProbeContext = {log};
 
-	const log = (...args: unknown[]) => {
-		if (debug) console.log(...args);
-	};
-	const ctx: ProbeContext = { debug, log };
-
-	// NOT PDF => PEEK ONLY, do not advance
 	if (!await peekIsPdfHeader(tokenizer)) return undefined;
 
-	// Confirmed PDF => ok to advance
 	log(`[PDF] Detected %PDF- header at abs=${tokenizer.position}`);
 
-	const reader = new PdfTokenizerReader(tokenizer, { debug });
+	const reader = new PdfTokenizerReader(tokenizer);
 
-	// pushback so we don't lose a line when probing for "stream"
 	let pendingLine: string | null = null;
 	const readLine = async (): Promise<string | null> => {
 		if (pendingLine !== null) {
@@ -251,7 +245,7 @@ async function _detectPdf(
 
 	log("[ROOT] Start parsing (PDF)");
 
-	let state = 0; // ROOT=0, OBJ=10
+	let state = 0;
 	let scannedLines = 0;
 
 	while (scannedLines++ < maxScanLines) {
@@ -276,7 +270,7 @@ async function _detectPdf(
 
 			if (!line.includes("<<")) continue;
 
-			const { dictText, streamInline } = await readDictionaryBlock(reader, line);
+			const {dictText, streamInline} = await readDictionaryBlock(reader, line);
 			if (!dictText) continue;
 
 			log(`[OBJ] Dictionary content: ${dictText.replace(/\s+/g, " ")}`);
@@ -371,7 +365,7 @@ async function _detectPdf(
 
 export const detectPdf: Detector = {
 	id: 'cfbf',
-	detect: async (tokenizer: ITokenizer):  Promise<FileTypeResult | undefined> => {
+	detect: async (tokenizer: ITokenizer): Promise<FileTypeResult | undefined> => {
 		return _detectPdf(tokenizer);
 	}
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
 			"license": "MIT",
 			"dependencies": {
 				"@borewit/text-codec": "^0.2.1",
+				"debug": "^4.4.3",
 				"read-next-line": "^0.5.0",
 				"sax": "^1.4.4"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.3.10",
 				"@tokenizer/s3": "^1.0.1",
+				"@types/debug": "^4.1.13",
 				"@types/node": "^25.0.3",
 				"@types/sax": "^1.2.7",
 				"chai": "^6.2.2",
@@ -2492,6 +2494,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/debug": {
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/node": {
 			"version": "25.0.3",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
@@ -2779,7 +2798,6 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -3418,7 +3436,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -46,12 +46,14 @@
 	"homepage": "https://github.com/Borewit/file-type-pdf#readme",
 	"dependencies": {
 		"@borewit/text-codec": "^0.2.1",
+		"debug": "^4.4.3",
 		"read-next-line": "^0.5.0",
 		"sax": "^1.4.4"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.10",
 		"@tokenizer/s3": "^1.0.1",
+		"@types/debug": "^4.1.13",
 		"@types/node": "^25.0.3",
 		"@types/sax": "^1.2.7",
 		"chai": "^6.2.2",


### PR DESCRIPTION
## Pull request overview

Refactors PDF detection logging to use the `debug` package instead of `console.log`, aiming to make verbose output opt-in via debug namespaces.

**Changes:**
- Added `debug` as a runtime dependency and `@types/debug` for TypeScript.
- Introduced `debug`-based loggers in `lib/index.ts` (detector) and `lib/PdfTokenizerReader.ts` (reader).
- Rewired existing debug output paths away from `console.log`.