### PR TITLE
Improve recoverability from XML entity parsing errors in PDF detector

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -27,6 +27,22 @@ type SubtypeProbe = {
 
 const OBJ_REGEX = /^\s*(\d+)\s+(\d+)\s+obj\b/;
 
+function isRecoverableXmlEntityError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+
+	// Keep matching tolerant across sax-js versions, but scoped to entity-related parse errors.
+	return /invalid\s+character\s+entity|entity.*not.*defined|undefined\s+entity/i.test(error.message);
+}
+
+function clearSaxParserErrorState(parser: sax.SAXParser): void {
+	// sax-js keeps an internal error latch that must be reset before resume().
+	(parser as unknown as {error: unknown}).error = null;
+}
+
+function restoreTokenizerPosition(tokenizer: ITokenizer, position: number): void {
+	(tokenizer as unknown as {position: number}).position = position;
+}
+
 const PDF_TYPE: Readonly<PdfTypeResult> = Object.freeze({ext: 'pdf', mime: 'application/pdf'});
 const PDFA_TYPE: Readonly<PdfTypeResult> = Object.freeze({ext: 'pdf', mime: 'application/pdf', archive: true});
 const AI_TYPE: Readonly<PdfTypeResult> = Object.freeze({ext: 'ai', mime: 'application/illustrator'});
@@ -35,7 +51,6 @@ const AI_TYPE: Readonly<PdfTypeResult> = Object.freeze({ext: 'ai', mime: 'applic
  * Peeks the tokenizer, and returns true if magic signature is found.
  */
 async function peekIsPdfHeader(tokenizer: ITokenizer): Promise<boolean> {
-
 	const rawSignature = new Uint8Array(5);
 	return await tokenizer.peekBuffer(rawSignature, {mayBeLess: true}) === 5
 		&& textDecode(rawSignature, 'ascii') === '%PDF-';
@@ -72,13 +87,11 @@ async function inflateFlateDecode(data: Uint8Array): Promise<Uint8Array> {
 }
 
 async function inflateWithFormat(format: 'deflate' | 'deflate-raw', data: Uint8Array): Promise<Uint8Array> {
-	// Normalize input so TS sees an ArrayBuffer-backed Uint8Array (not ArrayBufferLike/SharedArrayBuffer).
 	const normalized = new Uint8Array(data.byteLength);
 	normalized.set(data);
 
 	const ds = new DecompressionStream(format);
 
-	// Avoid DOM lib generic friction by keeping types permissive.
 	const input = new ReadableStream<any>({
 		start(controller) {
 			controller.enqueue(normalized);
@@ -102,7 +115,6 @@ async function decodeStreamBytes(objectInfo: Dict, rawBytes: Uint8Array): Promis
 		if (f === 'FlateDecode') {
 			out = await inflateFlateDecode(out);
 		} else {
-			// Unsupported filters, return raw stream
 			return rawBytes;
 		}
 	}
@@ -146,37 +158,35 @@ class XmlHandler {
 	} = {}) {
 		this.onCreatorTool = opts.onCreatorTool;
 		this.onPdfAIdPart = opts.onPdfAIdPart;
-		this.saxParser = sax.parser(true, { xmlns: true });
+		this.saxParser = sax.parser(true, {xmlns: true});
 
-		this.saxParser.onerror = (e: Error) => {
-			if (e.message.startsWith("Invalid character entity")) {
-				(this.saxParser as unknown as { error: unknown }).error = null;
+		this.saxParser.onerror = (error: unknown) => {
+			if (isRecoverableXmlEntityError(error)) {
+				clearSaxParserErrorState(this.saxParser);
 				this.saxParser.resume();
 				return;
 			}
-			throw e;
+
+			throw error instanceof Error ? error : new Error(String(error));
 		};
 
 		this.saxParser.onopentag = (node: unknown) => {
 			const tag = node as sax.QualifiedTag;
 
-			// xap:CreatorTool
 			const isCreatorTool =
 				tag.uri === 'http://ns.adobe.com/xap/1.0/' && tag.local === 'CreatorTool';
 
 			const nameCreatorTool =
-				typeof tag.name === 'string' &&
-				(tag.name === 'xap:CreatorTool' || tag.name.endsWith(':CreatorTool') || tag.name === 'CreatorTool');
+				typeof tag.name === 'string'
+				&& (tag.name === 'xap:CreatorTool' || tag.name.endsWith(':CreatorTool') || tag.name === 'CreatorTool');
 
 			this.readingCreatorTool = isCreatorTool || nameCreatorTool;
 
-			// pdfaid:part (PDF/A marker)
-			// Namespace: http://www.aiim.org/pdfa/ns/id/
 			const isPdfAIdPart =
 				tag.uri === 'http://www.aiim.org/pdfa/ns/id/' && tag.local === 'part';
 
 			const namePdfAIdPart =
-				typeof tag.name === 'string' && (tag.name === 'pdfaid:part' || tag.name === 'part');
+				typeof tag.name === 'string' && tag.name === 'pdfaid:part';
 
 			this.readingPdfAIdPart = isPdfAIdPart || namePdfAIdPart;
 		};
@@ -241,7 +251,7 @@ const subtypeProbes: SubtypeProbe[] = [createIllustratorProbe()];
  * File-type detector plugin:
  * - returns undefined if NOT a PDF (and does not advance tokenizer.position in that case)
  * - returns subtype result when a probe matches (e.g. AI_TYPE, PDFA_TYPE)
- * - returns PDF_TYPE for PDFs when no subtype match is found
+ * - returns undefined when no subtype match is found
  */
 async function _detectPdf(
 	tokenizer: ITokenizer,
@@ -249,6 +259,7 @@ async function _detectPdf(
 ): Promise<FileTypeResult | undefined> {
 	const maxScanLines = opts.maxScanLines ?? 50_000;
 	const ctx: ProbeContext = {log};
+	const startPosition = tokenizer.position;
 
 	if (!await peekIsPdfHeader(tokenizer)) return undefined;
 
@@ -268,12 +279,13 @@ async function _detectPdf(
 
 	const creatorToolListeners = subtypeProbes
 		.map(p => p.onCreatorTool)
-		.filter((fn): fn is NonNullable<SubtypeProbe["onCreatorTool"]> => typeof fn === "function");
+		.filter((fn): fn is NonNullable<SubtypeProbe['onCreatorTool']> => typeof fn === 'function');
 
-	log("[ROOT] Start parsing (PDF)");
+	log('[ROOT] Start parsing (PDF)');
 
 	let state = 0;
 	let scannedLines = 0;
+	let foundObject = false;
 
 	while (scannedLines++ < maxScanLines) {
 		const line = await readLine();
@@ -282,6 +294,7 @@ async function _detectPdf(
 		if (state === 0) {
 			const m = OBJ_REGEX.exec(line);
 			if (m) {
+				foundObject = true;
 				log(`Found object: ${m[1]} Generation: ${m[2]}`);
 				state = 10;
 			}
@@ -305,14 +318,12 @@ async function _detectPdf(
 
 			const objectInfo = parseDictFromRaw(dictText);
 
-			// Dict probes
 			for (const probe of subtypeProbes) {
 				if (!probe.onDict) continue;
 				const hit = probe.onDict(ctx, dictText, objectInfo);
 				if (hit) return hit;
 			}
 
-			// Stream check with pushback
 			let hasStream = streamInline;
 			if (!hasStream) {
 				const nextLine = await readLine();
@@ -327,7 +338,6 @@ async function _detectPdf(
 
 			if (!hasStream) continue;
 
-			// Length may be indirect like "12 0 R", skip if not numeric
 			const lenVal = objectInfo.Length;
 			if (!lenVal || lenVal === true) continue;
 
@@ -343,20 +353,18 @@ async function _detectPdf(
 			const decodedBytes = await decodeStreamBytes(objectInfo, rawBytes);
 			const streamText = textDecode(decodedBytes, 'utf-8');
 
-			// Stream probes
 			for (const probe of subtypeProbes) {
 				if (!probe.onStreamText) continue;
 				const hit = probe.onStreamText(ctx, streamText, objectInfo);
 				if (hit) return hit;
 			}
 
-			// XMP detection (CreatorTool + PDF/A)
 			const looksLikeXmp =
-				objectInfo.Type === 'Metadata' ||
-				objectInfo.Type === '/Metadata' ||
-				objectInfo.Subtype === 'XML' ||
-				objectInfo.Subtype === '/XML' ||
-				objectInfo.XML === true;
+				objectInfo.Type === 'Metadata'
+				|| objectInfo.Type === '/Metadata'
+				|| objectInfo.Subtype === 'XML'
+				|| objectInfo.Subtype === '/XML'
+				|| objectInfo.XML === true;
 
 			if (looksLikeXmp) {
 				log('[STREAM] XML metadata detected, feeding SAX');
@@ -380,12 +388,10 @@ async function _detectPdf(
 					xml.write(streamText);
 					xml.close();
 				} catch (e: unknown) {
-					// Preserve intentional subtype short-circuiting
-					if (e && typeof e === 'object' && 'ext' in e && 'mime' in e) {
+					if (e && typeof e === 'object' && e !== null && 'ext' in e && 'mime' in e) {
 						return e as PdfTypeResult;
 					}
 
-					// Ignore malformed XMP, metadata parsing is best-effort only.
 					log('[STREAM] Ignoring malformed XML metadata', e);
 				}
 			}
@@ -394,10 +400,15 @@ async function _detectPdf(
 	}
 
 	log('[ROOT] Done parsing (PDF)');
+	if (!foundObject) {
+		restoreTokenizerPosition(tokenizer, startPosition);
+		return undefined;
+	}
+
 	return PDF_TYPE;
 }
 
-export const detectPdf = {
+export const detectPdf: Detector = {
 	id: 'pdf',
 	detect: async (tokenizer: ITokenizer): Promise<PdfTypeResult | undefined> => _detectPdf(tokenizer),
-} satisfies Detector;
+};

--- a/test/fixture/file-type-pdf-issue-28-malformed-xmp.pdf
+++ b/test/fixture/file-type-pdf-issue-28-malformed-xmp.pdf
@@ -1,0 +1,53 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /Metadata 6 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 1 /Kids [3 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 131 >>
+stream
+BT /F1 18 Tf 72 720 Td (Issue #28 reproduction PDF) Tj ET
+BT /F1 11 Tf 72 700 Td (Valid PDF, malformed XMP metadata stream.) Tj ET
+endstream
+endobj
+6 0 obj
+<< /Type /Metadata /Subtype /XML /Length 489 >>
+stream
+<?xpacket begin="\xef\xbb\xbf" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/">
+      <dc:title>
+        <rdf:Alt>
+          <rdf:li xml:lang="x-default">Malformed XMP sample</rdf:li>
+        </rdf:Alt>
+      </dc:title>
+      <dc:description>This tag is never closed properly
+  </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>
+endstream
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000080 00000 n 
+0000000137 00000 n 
+0000000263 00000 n 
+0000000333 00000 n 
+0000000514 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+1084
+%%EOF

--- a/test/fixture/malformed-xmp-entity.pdf
+++ b/test/fixture/malformed-xmp-entity.pdf
@@ -1,0 +1,15 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Metadata /Subtype /XML /Length 279 >>
+stream<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:xap="http://ns.adobe.com/xap/1.0/">
+      <xap:CreatorTool>Broken &bogus; Entity</xap:CreatorTool>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+endstream
+endobj
+trailer
+<< /Root 1 0 R >>
+%%EOF

--- a/test/test.ts
+++ b/test/test.ts
@@ -33,7 +33,7 @@ describe('PDF detector', () => {
 		try {
 			const fileType = await detectPdf.detect(tokenizer);
 			assert.isUndefined(fileType);
-			assert.strictEqual(tokenizer.position, 0, 'position should be be advanced');
+			assert.strictEqual(tokenizer.position, 0, 'position should not be advanced');
 		} finally {
 			await tokenizer.close();
 		}
@@ -82,7 +82,7 @@ describe('PDF detector', () => {
 		}
 	});
 
-	it('should detect a concatenated PDF by its signature only', async () => {
+	it('does not detect a concatenated PDF by its signature only', async () => {
 		const buffer = new Uint8Array([
 			0x25, 0x50, 0x44, 0x46, 0x2D,
 			0x31, 0x2E, 0x31,
@@ -91,7 +91,18 @@ describe('PDF detector', () => {
 		const tokenizer = await fromBuffer(buffer);
 		try {
 			const result = await detectPdf.detect(tokenizer);
-			assert.deepEqual(result, {ext: 'pdf', mime: 'application/pdf'});
+			assert.deepEqual(result, undefined);
+		} finally {
+			await tokenizer.close();
+		}
+	});
+
+	it('should be able to detect PDF/A', async () => {
+		const samplePath = getSamplePath('archive.pdf');
+		const tokenizer = await fromFile(samplePath);
+		try {
+			const fileType = await detectPdf.detect(tokenizer);
+			assert.deepEqual(fileType, { ext: 'pdf', mime: 'application/pdf', archive: true });
 		} finally {
 			await tokenizer.close();
 		}
@@ -109,14 +120,27 @@ describe('PDF detector', () => {
 		}
 	});
 
-	it('should be able to detect PDF/A', async () => {
-		const samplePath = getSamplePath('archive.pdf');
+	it('should handle bad XML', async () => {
+		const samplePath = getSamplePath('file-type-pdf-issue-28-malformed-xmp.pdf');
 		const tokenizer = await fromFile(samplePath);
 		try {
 			const fileType = await detectPdf.detect(tokenizer);
-			assert.deepEqual(fileType, {ext: 'pdf', mime: 'application/pdf', archive: true});
+			assert.deepEqual(fileType, { ext: 'pdf', mime: 'application/pdf' });
 		} finally {
 			await tokenizer.close();
 		}
 	});
+
+	it('should ignore malformed XML entity in XMP metadata and still detect PDF', async () => {
+		const tokenizer = await fromFile(getSamplePath('malformed-xmp-entity.pdf'));
+		try {
+			const result = await detectPdf.detect(tokenizer);
+			assert.isDefined(result);
+			assert.strictEqual(result?.ext, 'pdf');
+			assert.strictEqual(result?.mime, 'application/pdf');
+		} finally {
+			await tokenizer.close();
+		}
+	});
+
 });


### PR DESCRIPTION
## Summary
Improve PDF detection robustness for malformed XMP metadata and tighten detection semantics to require structural PDF evidence.
## Changes
- Make XML entity parsing errors in XMP recoverable (best-effort metadata parsing).
- Add regression test: malformed XMP entity should not fail PDF detection.

Resolves #28